### PR TITLE
Plot pixel count bbox over GeoTiff

### DIFF
--- a/plot-geotiff-pixel-bbox.py
+++ b/plot-geotiff-pixel-bbox.py
@@ -63,7 +63,7 @@ def main():
     parser.add_argument('-upper_right', help='Upper Right corner pixel coordinates', dest='ur', default='100,1', required=False)
     parser.add_argument('-bbox_color', help='Color of bounding box overlay', dest='bbox_color', default='red', required=False)
     parser.add_argument('-o', help='Export plot as a PNG', dest='output', required=False)
-    parser.add_argument('-dpi', help='PNG export DPI', dest='png_dpi', type=int, required=False)
+    parser.add_argument('-dpi', help='PNG export DPI, default is 300 DPI', dest='png_dpi', type=int, required=False)
     parser.set_defaults(func=run)
     args = parser.parse_args()
     args.func(args)

--- a/plot-geotiff-pixel-bbox.py
+++ b/plot-geotiff-pixel-bbox.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+###########################################################
+# Plots a GeoTiff with a pixel count bounding box overlay.
+# Use to determine pixel values for ground control points
+# when geo-referencing or creating/testing cutlines.
+#######################################################
+import argparse
+import logging
+import rasterio
+from rasterio import windows
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
+logging.basicConfig(format='%(message)s', level=logging.INFO)
+logger = logging.getLogger()
+
+
+def run(args):
+    src_file = args.src
+    min_x = args.min_x
+    max_x = args.max_x
+    min_y = args.min_y
+    max_y = args.max_y
+
+    logging.info('Reading band 1 from ' + src_file)
+    raster_src = rasterio.open(src_file)
+
+    logging.info('Building overlay')
+    slice_raster = (slice(min_y, max_y), slice(min_x, max_x))
+    window_slice = windows.Window.from_slices(*slice_raster)
+
+    plt.imshow(raster_src.read(1))
+    ax = plt.gca()
+    ax.add_patch(
+        Rectangle(
+            (window_slice.col_off, window_slice.row_off),
+            width=window_slice.width,
+            height=window_slice.height,
+            fill=True,
+            alpha=.2,
+            color="red"
+        )
+    )
+
+    plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Plots GeoTiff with a pixel value bbox overlay')
+    parser.add_argument('-s', help='Filepath to raster', dest='src', required=True)
+    parser.add_argument('-x', help='Min Horizontal value', dest='min_x', type=int, default=1, required=False)
+    parser.add_argument('-X', help='Max Horizontal value', dest='max_x', type=int, default=100, required=False)
+    parser.add_argument('-y', help='Min Vertical value', dest='min_y', type=int, default=1, required=False)
+    parser.add_argument('-Y', help='Max Vertical value', dest='max_y', type=int, default=100, required=False)
+    parser.set_defaults(func=run)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/plot-geotiff-pixel-bbox.py
+++ b/plot-geotiff-pixel-bbox.py
@@ -6,6 +6,7 @@
 #######################################################
 import argparse
 import logging
+import os
 import rasterio
 from rasterio import windows
 import matplotlib.pyplot as plt
@@ -30,6 +31,7 @@ def run(args):
     window_slice = windows.Window.from_slices(*slice_raster)
 
     plt.imshow(raster_src.read(1))
+    plt.title(os.path.basename(src_file))
     ax = plt.gca()
     ax.add_patch(
         Rectangle(
@@ -37,7 +39,7 @@ def run(args):
             width=window_slice.width,
             height=window_slice.height,
             fill=True,
-            alpha=.2,
+            alpha=.5,
             color="red"
         )
     )


### PR DESCRIPTION
### Description
Add script to visualize GeoTiffs with a pixel coordinate bounding box overlay.
`./plot-geotiff-pixel-bbox.py -s GeoTiff -x Min_X -X Max_X -y Min_Y -Y Max_Y`

### Use case 
Determining pixel coordinates for ground control points when geo-referencing a GeoTiff (*UPDATED*)
- View plot in a new window 
   ```bash
   ./plot-geotiff-pixel-bbox.py \
   -s s3://prd-tnm/StagedProducts/Maps/HistoricalTopo/GeoTIFF/WI/WI_Eau\ Claire_803106_1985_100000_geo.tif \
   -lower_left 602,6870 -upper_right 9954,308
   ```
   ![image](https://user-images.githubusercontent.com/22895187/123772640-a1b84e00-d891-11eb-859b-3840c3d10228.png)
- Export plot as a PNG with 400 DPI and a blue overlay
   ```bash
   ./plot-geotiff-pixel-bbox.py \
   -s s3://prd-tnm/StagedProducts/Maps/HistoricalTopo/GeoTIFF/WI/WI_Eau\ Claire_803106_1985_100000_geo.tif \
   -lower_left 602,6870 -upper_right 9954,308 \
   -bbox_color blue \
   -o WI_Eau\ Claire_803106_1985_100000_geo.png \
   -dpi 400
   ```
   ![WI_Eau Claire_803106_1985_100000_geo](https://user-images.githubusercontent.com/22895187/124662863-f8fc8680-de6e-11eb-9d5e-678ede20439e.png)
